### PR TITLE
fix: Fix exit status

### DIFF
--- a/opthub_runner_admin/evaluator/main.py
+++ b/opthub_runner_admin/evaluator/main.py
@@ -65,7 +65,7 @@ def evaluate(args: Args) -> None:  # noqa: C901, PLR0915
             LOGGER.exception("Error occurred while fetching message from SQS.")
             signal.signal(signal.SIGTERM, signal.SIG_DFL)
             signal.signal(signal.SIGINT, signal.SIG_DFL)
-            sys.exit(0)
+            sys.exit(1)
 
         except Exception:
             LOGGER.exception("Error occurred while fetching message from SQS.")
@@ -200,5 +200,5 @@ def evaluate(args: Args) -> None:  # noqa: C901, PLR0915
             if isinstance(error, KeyboardInterrupt):
                 signal.signal(signal.SIGTERM, signal.SIG_DFL)
                 signal.signal(signal.SIGINT, signal.SIG_DFL)
-                sys.exit(0)
+                sys.exit(1)
             continue

--- a/opthub_runner_admin/main.py
+++ b/opthub_runner_admin/main.py
@@ -2,6 +2,7 @@
 
 import logging
 import signal
+import sys
 from pathlib import Path
 from types import FrameType
 from typing import TYPE_CHECKING, Any, cast
@@ -67,9 +68,11 @@ def auth(username: str, password: str) -> None:
             click.echo("Too many requests. Please try again later.")
         else:
             click.echo(f"An error occurred: {error_code}")
+        sys.exit(1)
     except Exception as e:
         # another exception
         click.echo(f"An unexpected error occurred: {e}")
+        sys.exit(1)
 
 
 signal.signal(signal.SIGTERM, signal_handler)

--- a/opthub_runner_admin/scorer/main.py
+++ b/opthub_runner_admin/scorer/main.py
@@ -71,7 +71,7 @@ def calculate_score(args: Args) -> None:  # noqa: PLR0915
             LOGGER.exception("Error occurred while fetching message from SQS.")
             signal.signal(signal.SIGTERM, signal.SIG_DFL)
             signal.signal(signal.SIGINT, signal.SIG_DFL)
-            sys.exit(0)
+            sys.exit(1)
 
         except Exception:
             LOGGER.exception("Error occurred while fetching message from SQS.")
@@ -239,5 +239,5 @@ def calculate_score(args: Args) -> None:  # noqa: PLR0915
             if isinstance(error, KeyboardInterrupt):
                 signal.signal(signal.SIGTERM, signal.SIG_DFL)
                 signal.signal(signal.SIGINT, signal.SIG_DFL)
-                sys.exit(0)
+                sys.exit(1)
             continue


### PR DESCRIPTION
- authに失敗した場合にプログラムが終了するように変更
- エラーが起きた場合にsys.exit(0)で終了していたため、sys.exit(1)に変更