### PR TITLE
fix: Error handling when authentication fails and the Docker image ca…

### DIFF
--- a/opthub_runner_admin/main.py
+++ b/opthub_runner_admin/main.py
@@ -80,8 +80,6 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 
 @click.command(help="OptHub Runner.")
-@click.option("--username", "-u", "username", required=True, prompt=True)
-@click.option("--password", "-p", "password", prompt=True, hide_input=True)
 @click.option(
     "-i",
     "--interval",
@@ -120,8 +118,6 @@ signal.signal(signal.SIGTERM, signal_handler)
 @click.pass_context
 def run(
     ctx: click.Context,
-    username: str,
-    password: str,
     interval: int,
     timeout: int,
     rm: bool,
@@ -131,6 +127,13 @@ def run(
     command: list[str],
 ) -> None:
     """The entrypoint of CLI."""
+    # Show the message to the user and ask for the username and password
+    click.echo(
+        click.style("Note: Make sure to authenticate using the competition administrator's account.", fg="yellow"),
+    )
+    username = click.prompt("Username", type=str)
+    password = click.prompt("Password", type=str, hide_input=True)
+
     if ctx.default_map is None:
         msg = "Configuration file is not loaded."
         raise ValueError(msg)

--- a/opthub_runner_admin/models/exception.py
+++ b/opthub_runner_admin/models/exception.py
@@ -35,3 +35,15 @@ class AuthenticationError(Exception):
         """Handle the GraphQL error."""
         click.echo(str(self))
         sys.exit(1)
+
+
+class DockerImageNotFoundError(Exception):
+    """Exception raised when the Docker image is not found. It may occur if you lack the permissions to access it."""
+
+    def __init__(self) -> None:
+        """Initialize the exception."""
+        msg = (
+            "Cannot access the Docker image. Please check your permissions. "
+            "If you're not authenticated using the competition administrator's account, please do so."
+        )
+        super().__init__(msg)


### PR DESCRIPTION
close #62 
以下の2つを実装した。

- evaluatorとscorer起動時、Usernameを入力するプロンプトの上に注意書きを表示
  - 注意書きの内容はコンペの管理者で認証して下さいという内容
- DockerImageをgetmatchで取って来れなかった場合に、DockerImageNotFoundErrorを出してexit
  - getmatchの段階ではsolutionはまだ取ってきていないので、Evaluation(Failed)は保存せず終了